### PR TITLE
use fetchall()

### DIFF
--- a/flask_pg_extras/__init__.py
+++ b/flask_pg_extras/__init__.py
@@ -30,6 +30,8 @@ def db_execute_results(db, q):
     """
     result = db.engine.execute(text(q))
 
-    print(tabulate([row for row in result], headers=result.keys()))
+    result_fetchall = result.fetchall()
+
+    print(tabulate([list(r) for r in result_fetchall], headers=result.keys()))
 
     return result


### PR DESCRIPTION
Seeing 
```
ValueError: headers for a list of dicts is not a dict or a keyword
```

Right now, result is a LegacyCursorResult object.

This PR leverages .fetchall() to convert all rows into tuples, which we then convert to a list.